### PR TITLE
MudDataGrid: Refactor FilterDefintions API

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAggregationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAggregationExample.razor
@@ -37,14 +37,14 @@
 
     IEnumerable<Model> _items = new List<Model>()
     {
-        new Model("Sam", 56, Severity.Normal, 50_000.00M, DateTime.Parse("3/5/2005"), false), 
-        new Model("Alicia", 54, Severity.Info, 75_000.00M, DateTime.Parse("1/17/2010"), false), 
-        new Model("Ira", 27, Severity.Success, 102_000.00M, DateTime.Parse("6/15/2017"), true),
-        new Model("John", 32, Severity.Warning, 132_000.00M, DateTime.Parse("12/23/2021"), true),
-        new Model("Fred", 65, Severity.Warning, 87_000.00M, DateTime.Parse("7/3/2003"), false), 
-        new Model("Tabitha", 33, Severity.Info, 157_000.00M, DateTime.Parse("2/12/2015"), true), 
-        new Model("Hunter", 22, Severity.Success, 43_000.00M, DateTime.Parse("9/20/2017"), false),
-        new Model("Esme", 55, Severity.Warning, 149_000.00M, DateTime.Parse("8/1/2017"), true)
+        new Model("Sam", 56, Severity.Normal, 50_000.00M, DateTime.ParseExact("3/5/2005", "M/d/yyyy", null), false), 
+        new Model("Alicia", 54, Severity.Info, 75_000.00M, DateTime.ParseExact("1/17/2010", "M/dd/yyyy", null), false), 
+        new Model("Ira", 27, Severity.Success, 102_000.00M, DateTime.ParseExact("6/15/2017", "M/dd/yyyy", null), true),
+        new Model("John", 32, Severity.Warning, 132_000.00M, DateTime.ParseExact("12/23/2021", "M/dd/yyyy", null), true),
+        new Model("Fred", 65, Severity.Warning, 87_000.00M, DateTime.ParseExact("7/3/2003", "M/d/yyyy", null), false), 
+        new Model("Tabitha", 33, Severity.Info, 157_000.00M, DateTime.ParseExact("2/12/2015", "M/dd/yyyy", null), true), 
+        new Model("Hunter", 22, Severity.Success, 43_000.00M, DateTime.ParseExact("9/20/2017", "M/dd/yyyy", null), false),
+        new Model("Esme", 55, Severity.Warning, 149_000.00M, DateTime.ParseExact("8/1/2017", "M/d/yyyy", null), true)
     };
 
     AggregateDefinition<Model> _ageAggregation = new AggregateDefinition<Model>

--- a/src/MudBlazor/Components/DataGrid/GridState.cs
+++ b/src/MudBlazor/Components/DataGrid/GridState.cs
@@ -16,12 +16,13 @@ namespace MudBlazor
         public Func<T, object> SortBy { get; set; }
 
         public SortDirection SortDirection { get; set; }
+
+        public ICollection<FilterDefinition<T>> FilterDefinitions { get; set; }
     }
 
     public class GridData<T>
     {
         public IEnumerable<T> Items { get; set; }
         public int TotalItems { get; set; }
-
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -48,14 +48,18 @@ namespace MudBlazor
                .AddClass($"mud-elevation-{Elevation}", !Outlined)
               .AddClass(Class)
             .Build();
+
         protected string _tableStyle =>
             new StyleBuilder()
             .AddStyle($"height", Height, !string.IsNullOrWhiteSpace(Height))
             .Build();
+
         protected string _headClassname => new CssBuilder("mud-table-head")
             .AddClass(HeaderClass).Build();
+
         protected string _footClassname => new CssBuilder("mud-table-foot")
             .AddClass(FooterClass).Build();
+
         protected int numPages
         {
             get
@@ -73,10 +77,11 @@ namespace MudBlazor
         internal int editingItemHash;
         internal T _previousEditingItem;
         internal bool isEditFormOpen;
+
         internal string GetHorizontalScrollbarStyle() => HorizontalScrollbar ? ";display: block; overflow-x: auto;" : string.Empty;
 
         // converters
-        Converter<bool, bool?> _oppositeBoolConverter = new Converter<bool, bool?>
+        private Converter<bool, bool?> _oppositeBoolConverter = new Converter<bool, bool?>
         {
             SetFunc = value => value ? false : true,
             GetFunc = value => value.HasValue ? !value.Value : true,
@@ -215,7 +220,7 @@ namespace MudBlazor
 
         /// <summary>
         /// The list of FilterDefinitions that have been added to the data grid. FilterDefinitions are managed by the data
-        /// grid automatically when using the built in filter UI. You can also programmatically manage these definitions 
+        /// grid automatically when using the built in filter UI. You can also programmatically manage these definitions
         /// through this collection.
         /// </summary>
         [Parameter] public List<FilterDefinition<T>> FilterDefinitions { get; set; } = new List<FilterDefinition<T>>();
@@ -246,7 +251,7 @@ namespace MudBlazor
         [Parameter] public Func<T, int, string> RowStyleFunc { get; set; }
 
         /// <summary>
-        /// Set to true to enable selection of multiple rows. 
+        /// Set to true to enable selection of multiple rows.
         /// </summary>
         [Parameter] public bool MultiSelection { get; set; }
 
@@ -268,7 +273,7 @@ namespace MudBlazor
         /// <summary>
         /// The data to display in the table. MudTable will render one row per item
         /// </summary>
-        /// 
+        ///
         [Parameter]
         public IEnumerable<T> Items
         {
@@ -315,7 +320,7 @@ namespace MudBlazor
 
         /// <summary>
         /// Setting a height will allow to scroll the table. If not set, it will try to grow in height. You can set this to any CSS value that the
-        /// attribute 'height' accepts, i.e. 500px. 
+        /// attribute 'height' accepts, i.e. 500px.
         /// </summary>
         [Parameter] public string Height { get; set; }
 
@@ -330,7 +335,7 @@ namespace MudBlazor
         [Parameter] public Func<T, bool> QuickFilter { get; set; } = null;
 
         /// <summary>
-        /// Allows adding a custom header beyond that specified in the Column component. Add HeaderCell 
+        /// Allows adding a custom header beyond that specified in the Column component. Add HeaderCell
         /// components to add a custom header.
         /// </summary>
         [Parameter] public RenderFragment Header { get; set; }
@@ -481,15 +486,19 @@ namespace MudBlazor
                 }
             }
         }
+
         private bool _groupable = false;
+
         /// <summary>
         /// If set, a grouped column will be expanded by default.
         /// </summary>
         [Parameter] public bool GroupExpanded { get; set; }
+
         /// <summary>
         /// CSS class for the groups.
         /// </summary>
         [Parameter] public string GroupClass { get; set; }
+
         /// <summary>
         /// CSS styles for the groups.
         /// </summary>
@@ -521,9 +530,11 @@ namespace MudBlazor
                 return GetItemsOfPage(CurrentPage, RowsPerPage);
             }
         }
+
         public HashSet<T> Selection { get; set; } = new HashSet<T>();
         public bool HasPager { get; set; }
-        GridData<T> _server_data = new GridData<T>() { TotalItems = 0, Items = Array.Empty<T>() };
+        private GridData<T> _server_data = new GridData<T>() { TotalItems = 0, Items = Array.Empty<T>() };
+
         public IEnumerable<T> FilteredItems
         {
             get
@@ -548,7 +559,9 @@ namespace MudBlazor
                 return Sort(items);
             }
         }
+
         public Interfaces.IForm Validator { get; set; } = new DataGridRowValidator();
+
         internal Column<T> GroupedColumn
         {
             get
@@ -561,7 +574,7 @@ namespace MudBlazor
 
         #region Computed Properties
 
-        bool hasFooter
+        private bool hasFooter
         {
             get
             {
@@ -614,7 +627,9 @@ namespace MudBlazor
                 Page = CurrentPage,
                 PageSize = RowsPerPage,
                 SortBy = _sortBy,
-                SortDirection = _direction
+                SortDirection = _direction,
+                // Additional ToList() here to decouple clients from internal list avoiding runtime issues
+                FilterDefinitions = FilterDefinitions.ToList()
             };
 
             _server_data = await ServerData(state);
@@ -724,7 +739,7 @@ namespace MudBlazor
 
         /// <summary>
         /// This method notifies the consumer that changes to the data have been committed
-        /// and what those changes are. This variation of the method is used when the EditMode 
+        /// and what those changes are. This variation of the method is used when the EditMode
         /// is anything but Cell since the _editingItem is used.
         /// </summary>
         /// <returns></returns>
@@ -785,12 +800,15 @@ namespace MudBlazor
                 case Page.First:
                     CurrentPage = 0;
                     break;
+
                 case Page.Last:
                     CurrentPage = Math.Max(0, numPages - 1);
                     break;
+
                 case Page.Next:
                     CurrentPage = Math.Min(numPages - 1, CurrentPage + 1);
                     break;
+
                 case Page.Previous:
                     CurrentPage = Math.Max(0, CurrentPage - 1);
                     break;
@@ -959,7 +977,7 @@ namespace MudBlazor
                 StateHasChanged();
                 return;
             }
-            
+
             var groupings = CurrentPageItems.GroupBy(GroupedColumn.groupBy);
 
             if (_groupExpansions.Count == 0)
@@ -991,7 +1009,7 @@ namespace MudBlazor
                     c.RemoveGrouping();
             }
 
-            GroupItems();       
+            GroupItems();
         }
 
         internal void ToggleGroupExpansion(GroupDefinition<T> g)
@@ -1025,6 +1043,5 @@ namespace MudBlazor
         }
 
         #endregion
-
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
This PR allows consumers of the Grid to handle FilterDefinitions in a more flexible way.
Especially when using server-side data loading from an arbitrary API, this can come in handy.
The consumer of the grid can decide now within the ServerLoad callback how to serialize the filters so that they can be consumed by the API.

Example below shows handling the Expressions now provided by the FilterDefinitions class.
Alternatively, for sure, the consumer can still fetch the individual properties (e.g Field, Operator, Value etc.) and create its own filter logic if required.

## How Has This Been Tested?
Existing Tests in DataGridTests.
Additional Tests for new API method will be added after conclusion of discussion.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Example usage:

```cs
private async Task<GridData<Model>> ServerReload(GridState<Model> state)
{
	// via the GridState, the MudDataGrid will provide information on pagination, searching and filtering.
	// The FilterDefinition class allows for retrieving the filter as Expression or as Func<T, bool>.
	// For transfer to an API the easiest approach is to project the definitions to their respective expression
	// And use the ToString() overloaded method of the Expression type to be able to serialize the resolved expression:
	var filterStrings = state.FilterDefinitions.Select(fd => fd.GenerateFilterExpression().ToString());

	// using this List<string> of filters, you can forward this information to the API (usually you will have some sort of RequestDto carrying more information like pagination and sorting)
	var requestDto = CreateRequestDto(..., filterStrings); // some custom logic to create your request model.

	var response = await SomeService.GetModels(requestDto); // fetch data from the API

	// ... Some error handling most likey happening here...

	return new GridData<Model>() { TotalItems = response.TotalRecords, Items = response.Data };
}

// ...
// From the API, you can take the filter information from your request DTO and use them in your data query.
// When using for example EntityFramework.Core to fetch your data from a DB, the most convenient approach would
// be to use System.Linq.Dynamic.Core package and simply feed the filters to your IQueryable instance:
public async Task<PagedResponse<Model>> GetModels(YourRequestDto filter)
{
	var baseQuery = AppDbContext.Models.AsNoTracking();
	var combinedFilter = String.Join(" or ", filter.FilterStrings) // of course you can also use " and " to combine individual filters
	var filteredQuery = baseQuery.Where(combinedFilter); // This line requires System.Linq.Dynamic.Core to work

	// perform further steps on your db entities (e.g. sorting, pagination, projection etc.)
	// ...
	return serviceResponse;
}
```


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
