### PR TITLE
MudDataGrid: Improve cursor styling on resize operation

### DIFF
--- a/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
@@ -60,6 +60,8 @@ namespace MudBlazor
             _mouseMoveSubscriptionId = await _eventListener.SubscribeGlobal<MouseEventArgs>(EventMouseMove, 0, OnApplicationMouseMove);
             _mouseUpSubscriptionId = await _eventListener.SubscribeGlobal<MouseEventArgs>(EventMouseUp, 0, OnApplicationMouseUp);
 
+            _dataGrid.IsResizing = true;
+            _dataGrid.ExternalStateHasChanged();
             return true;
         }
 
@@ -72,6 +74,8 @@ namespace MudBlazor
         {
             var requiresUpdate = _mouseMoveSubscriptionId != default || _mouseUpSubscriptionId != default;
 
+            _dataGrid.IsResizing = false;
+            _dataGrid.ExternalStateHasChanged();
             await UnsubscribeApplicationEvents();
 
             if (requiresUpdate)

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -14,7 +14,7 @@ else if (Column != null && !Column.Hidden)
         <span class="column-header">
             @if (sortable)
             {
-                <span class="sortable-column-header" @onclick="SortChangedAsync">
+                <span class="@_sortHeaderClass" @onclick="SortChangedAsync">
                     @if (Column.HeaderTemplate != null)
                     {
                         @Column.HeaderTemplate(Column.headerContext)
@@ -36,7 +36,7 @@ else if (Column != null && !Column.Hidden)
                     @computedTitle
                 }
             }
-            <span class="column-options">
+            <span class="@_optionsClass">
                 @if (sortable)
                 {
                     if (_initialDirection == SortDirection.None)

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -49,6 +49,18 @@ namespace MudBlazor
                 .AddClass("mud-resizer")
             .Build();
 
+        private string _sortHeaderClass =>
+            new CssBuilder()
+                .AddClass("sortable-column-header")
+                .AddClass("cursor-pointer", when: !_isResizing)
+            .Build();
+
+        private string _optionsClass =>
+            new CssBuilder()
+                .AddClass("column-options")
+                .AddClass("cursor-pointer", when: !_isResizing)
+            .Build();
+
         private ElementReference _headerElement;
 
         private double? _width;

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -30,7 +30,7 @@
                     </MudToolBar>
                  }
             }
-            <div @ref=_gridElement class="mud-table-container" style="@_tableStyle">
+            <div @ref=_gridElement class="@_tableClass" style="@_tableStyle">
                 <table class="mud-table-root">
                     @if (ColGroup != null)
                     {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -61,6 +61,11 @@ namespace MudBlazor
                 .AddStyle("display", "block", when: HorizontalScrollbar)
             .Build();
 
+        protected string _tableClass =>
+            new CssBuilder("mud-table-container")
+                .AddClass("cursor-col-resize", when: IsResizing)
+            .Build();
+
         protected string _headClassname => new CssBuilder("mud-table-head")
             .AddClass(HeaderClass).Build();
 
@@ -1162,6 +1167,7 @@ namespace MudBlazor
         #region Resize feature
 
         [Inject] private IEventListener EventListener { get; set; }
+        internal bool IsResizing { get; set; }
 
         private ElementReference _gridElement;
         private DataGridColumnResizeService<T> _resizeService;

--- a/src/MudBlazor/Styles/components/_datagrid.scss
+++ b/src/MudBlazor/Styles/components/_datagrid.scss
@@ -51,7 +51,6 @@
             justify-content: space-between;
 
             .sortable-column-header {
-                cursor: pointer;
                 width: 100%;
             }
 
@@ -68,7 +67,6 @@
             }
 
             .column-options {
-                cursor: pointer;
                 display: inline-flex;
                 align-items: center;
                 flex-direction: inherit;


### PR DESCRIPTION
Just small style adaptation when resizing a column inside the DataGrid.
Please note: Even though using the class .cursor-col-resize which resovles to css rule `cursor: col-resize !important`, this style is still in conflict with `cursor: pointer` being applied on the options buttons and sometimes even with the sortable header, even though I actively remove the cursor class from those.
Not sure if this is a bug or if I'm missing something here
